### PR TITLE
🐛  Fix: wines 페이지 전체 탭일때 평점이 달린 와인은 안 나오는 버그 수정

### DIFF
--- a/src/hooks/useWineFilter.ts
+++ b/src/hooks/useWineFilter.ts
@@ -29,7 +29,7 @@ export const useWineFilter = () => {
         type: wineType,
         minPrice,
         maxPrice,
-        rating: ratingRange[0],
+        rating: undefined,
         name: searchTerm,
       };
 
@@ -40,9 +40,12 @@ export const useWineFilter = () => {
 
         console.log("와인리스트 :::", wineList);
 
-        if (ratingRange[1] < 5) {
+        if (ratingRange[0] !== 0) {
+          // 전체가 아닐 때
           wineList = wineList.filter(
-            (wine) => wine.avgRating <= ratingRange[1]
+            (wine) =>
+              wine.avgRating >= ratingRange[0] && // 최소값 체크
+              wine.avgRating < ratingRange[1] // 최대값 체크
           );
         }
         // 클라이언트 측 정렬


### PR DESCRIPTION
전체 탭일 때 평점이 달린 와인이 안 나오는 버그를 발견해서 급하게 수정했습니다.

또한, 별점 구간 별로 필터를 걸었을 때 리스트가 잘못 나오던 버그도 같이 수정했습니다.